### PR TITLE
update(setup.js & package.json)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 node_js:
   - "8"
+before_install:
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.3.2
+  - export PATH="$HOME/.yarn/bin:$PATH"
 before_script:
   - node setup
 script: 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,23 @@
+# Test against the latest version of this Node.js version
+environment:
+  nodejs_version: "8"
+  
+# Install scripts. (runs after repo cloning)
+install:
+  # Get the latest stable version of Node.js or io.js
+  - ps: Install-Product node $env:nodejs_version
+  # install modules
+  - npm install -g gulp
+  - node setup
+  - gulp build
+
+# Post-install test scripts.
+test_script:
+  # Output useful info for debugging.
+  - node --version
+  - npm --version
+  # run tests
+  - npm test
+
+# Don't actually build.
+build: off

--- a/package.json
+++ b/package.json
@@ -20,17 +20,16 @@
     "type": "git",
     "url": "https://github.com/vegarringdal/skeleton-plugin-typescript"
   },
-  "scripts": {
-    "setup": "node setup",
-	"setup": "node setup",
-	"setup-version": "node setup -v",
-	"setup-version-specific": "node setup -v 0.5.0",
-    "run-watch": "gulp watch",
-    "test-watch": "./node_modules/.bin/jest --config=jest.config.json --watch",
-    "build": "gulp build",
-    "test": "./node_modules/.bin/jest --config=jest.config.json",
-    "build-all": "node setup & gulp build & gulp test"
-  },
+    "scripts": {
+        "setup": "node setup",
+        "setup-version": "node setup -v",
+        "setup-version-specific": "node setup -v 0.5.0",
+        "run-watch": "./node_modules/.bin/gulp watch",
+        "test-watch": "./node_modules/.bin/jest --config=jest.config.json --watch",
+        "build": "./node_modules/.bin/gulp build",
+        "test": "./node_modules/.bin/jest --config=jest.config.json",
+        "build-all": "npm run setup & npm run build & npm run test"
+    },
   "devDependencies": {
     "@types/jest": "^21.1.6",
     "@types/jsdom": "^11.0.4",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
   },
   "scripts": {
     "setup": "node setup",
+	"setup": "node setup",
+	"setup-version": "node setup -v",
+	"setup-version-specific": "node setup -v 0.5.0",
     "run-watch": "gulp watch",
     "test-watch": "./node_modules/.bin/jest --config=jest.config.json --watch",
     "build": "gulp build",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
         "devDependencies": {}
     },
     "dependencies": {
-        "aurelia-framework": "1.1.5"
+        "aurelia-framework": "^1.1.5"
     },
     "aurelia": {
         "usedBy": [],

--- a/package.json
+++ b/package.json
@@ -1,28 +1,28 @@
 {
-  "name": "aurelia-skeleton-plugin-typescript",
-  "version": "0.5.0",
-  "description": "Create typescript plugins for Aurelia",
-  "keywords": [
-    "aurelia",
-    "plugin",
-    "skeleton",
-    "typescript"
-  ],
-  "homepage": "https://github.com/vegarringdal/skeleton-plugin-typescript",
-  "bugs": {
-    "url": "https://github.com/vegarringdal/skeleton-plugin-typescript/issues"
-  },
-  "license": "MIT",
-  "author": "Vegar Ringdal (vegar.ringdal@gmail.com)",
-  "main": "dist/commonjs/index.js",
-  "typings": "dist/commonjs/index.d.ts",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/vegarringdal/skeleton-plugin-typescript"
-  },
+    "name": "aurelia-skeleton-plugin-typescript",
+    "version": "0.5.0",
+    "description": "Create typescript plugins for Aurelia",
+    "keywords": [
+        "aurelia",
+        "plugin",
+        "skeleton",
+        "typescript"
+    ],
+    "homepage": "https://github.com/vegarringdal/skeleton-plugin-typescript",
+    "bugs": {
+        "url": "https://github.com/vegarringdal/skeleton-plugin-typescript/issues"
+    },
+    "license": "MIT",
+    "author": "Vegar Ringdal (vegar.ringdal@gmail.com)",
+    "main": "dist/commonjs/index.js",
+    "typings": "dist/commonjs/index.d.ts",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/vegarringdal/skeleton-plugin-typescript"
+    },
     "scripts": {
         "setup": "node setup",
-        "setup-version": "node setup -v",
+        "setup-version": "node setup --Version",
         "setup-version-specific": "node setup -v 0.5.0",
         "run-watch": "./node_modules/.bin/gulp watch",
         "test-watch": "./node_modules/.bin/jest --config=jest.config.json --watch",
@@ -30,50 +30,50 @@
         "test": "./node_modules/.bin/jest --config=jest.config.json",
         "build-all": "npm run setup & npm run build & npm run test"
     },
-  "devDependencies": {
-    "@types/jest": "^21.1.6",
-    "@types/jsdom": "^11.0.4",
-    "@types/node": "^8.0.53",
-    "aurelia-bootstrapper": "^2.1.1",
-    "aurelia-loader-nodejs": "^1.0.1",
-    "aurelia-pal-nodejs": "^1.0.0-beta.2.0.0",
-    "aurelia-testing": "^1.0.0-beta.4.0.0",
-    "del": "^3.0.0",
-    "gulp": "^3.9.1",
-    "gulp-plumber": "^1.1.0",
-    "gulp-run": "^1.7.1",
-    "gulp-sourcemaps": "^2.6.1",
-    "gulp-tslint": "^8.1.2",
-    "gulp-typescript": "^3.2.3",
-    "jest": "^21.2.1",
-    "jsdom": "^11.3.0",
-    "merge2": "^1.2.0",
-    "require-dir": "^0.3.2",
-    "run-sequence": "^2.2.0",
-    "ts-jest": "^21.2.2",
-    "tslint": "^5.8.0",
-    "typescript": "^2.6.1",
-    "vinyl-paths": "^2.1.0"
-  },
-  "jspm": {
-    "registry": "npm",
-    "main": "index",
-    "format": "cjs",
-    "directories": {
-      "dist": "dist/commonjs"
+    "devDependencies": {
+        "@types/jest": "^21.1.6",
+        "@types/jsdom": "^11.0.4",
+        "@types/node": "^8.0.53",
+        "aurelia-bootstrapper": "^2.1.1",
+        "aurelia-loader-nodejs": "^1.0.1",
+        "aurelia-pal-nodejs": "^1.0.0-beta.2.0.0",
+        "aurelia-testing": "^1.0.0-beta.4.0.0",
+        "del": "^3.0.0",
+        "gulp": "^3.9.1",
+        "gulp-plumber": "^1.1.0",
+        "gulp-run": "^1.7.1",
+        "gulp-sourcemaps": "^2.6.1",
+        "gulp-tslint": "^8.1.2",
+        "gulp-typescript": "^3.2.3",
+        "jest": "^21.2.1",
+        "jsdom": "^11.3.0",
+        "merge2": "^1.2.0",
+        "require-dir": "^0.3.2",
+        "run-sequence": "^2.2.0",
+        "ts-jest": "^21.2.2",
+        "tslint": "^5.8.0",
+        "typescript": "^2.6.1",
+        "vinyl-paths": "^2.1.0"
     },
-    "devDependencies": {}
-  },
-  "dependencies": {
-    "aurelia-framework": "1.1.5"
-  },
-  "aurelia": {
-    "usedBy": [],
-    "build": {
-      "resources": [
-        "aurelia-skeleton-plugin-typescript",
-        "aurelia-skeleton-plugin-typescript/index"
-      ]
+    "jspm": {
+        "registry": "npm",
+        "main": "index",
+        "format": "cjs",
+        "directories": {
+            "dist": "dist/commonjs"
+        },
+        "devDependencies": {}
+    },
+    "dependencies": {
+        "aurelia-framework": "1.1.5"
+    },
+    "aurelia": {
+        "usedBy": [],
+        "build": {
+            "resources": [
+                "aurelia-skeleton-plugin-typescript",
+                "aurelia-skeleton-plugin-typescript/index"
+            ]
+        }
     }
-  }
 }

--- a/sample/package.json
+++ b/sample/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "aurelia-skeleton-navigation-typescript-fusebox",
-    "version": "1.0.0",
+    "name": "aurelia-skeleton-plugin-typescript-sample",
+    "version": "0.5.0",
     "description": "A starter kit for building a standard navigation-style app with Aurelia and TypeScript and fusebox.",
     "keywords": [
         "aurelia",
@@ -47,6 +47,6 @@
         "fuse-box-typechecker": "^2.6.2"
     },
     "dependencies": {
-        "aurelia-skeleton-plugin-typescript": "../aurelia-skeleton-plugin-typescript-0.5.0.tgz"
+        "aurelia-framework": "1.1.5"
     }
 }

--- a/sample/package.json
+++ b/sample/package.json
@@ -47,6 +47,6 @@
         "fuse-box-typechecker": "^2.6.2"
     },
     "dependencies": {
-        "aurelia-framework": "1.1.5"
+        "aurelia-framework": "^1.1.5"
     }
 }

--- a/setup.js
+++ b/setup.js
@@ -63,10 +63,10 @@ function updateSampleConfig() {
     PLUGIN_VERSION = obj.version || PLUGIN_VERSION;
 
     if (versions && (versions.length > 0)) {
-      if (argVersion != undefined && argVersionNumber == undefined) {
+      if (argVersion != undefined && argVersionNumber == undefined && (argVersion == '-v' || argVersion == '--Version')) {
         versions[versions.length - 1] = safeIncreaseVersion(versions[versions.length - 1]);
       }
-      if (argVersionNumber != undefined) {
+      if (argVersion != undefined && argVersionNumber != undefined && (argVersion == '-v' || argVersion == '--Version')) {
         versions = argVersionNumber.split('.');
       }
       console.info(`Version changing ${obj.version} => ${versions.join('.')}`);


### PR DESCRIPTION
Hello @vegarringdal 

Thanks for your awesome work :)
I changed your updating system, now you don't need `.tgz` any more.

If you accept my pull request, the dependencies of the `Sample` folder will be updated directly from the `Plugin` folder and there will be no need to build the package.

Of course, we have more options in `package.json`

- "setup": "node setup", // Keep the current state
- "setup-version": "node setup -v", // +1 to the current version (increamental)
- "setup-version-specific": "node setup -v 0.5.0", // Set the specifice version

The final point is that the `Plugin` version and `Sample` will always be the same!

I updated your `travis` config to use the latest version of `yarn` in the `travis` server

I added `appveyor.yml` for supporting `appveyor` CI/CD too.

![untitled](https://user-images.githubusercontent.com/8418700/33702716-213a80c0-db3a-11e7-957a-253e337f1de3.png)

